### PR TITLE
feat: add docker compose configuration and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ docker run --name acestream -d -p 6878:6878 docker-acestream-ubuntu-home
 
 This command will run a container named `acestream`, in detached mode (`-d`), mapping the host's port `6878` to the container, allowing you to access the Acestream service through this port.
 
+## Running the Container via Docker Compose
+
+Download or copy the contents of ``docker-compose.yml`` file.
+
+Then, on the same place where it is located:
+
+```bash
+docker compose up -d
+```
+
+### Updating with Docker Compose
+
+Execute:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
 ## Accessing the Web Interface
 
 Once the container is running and there are no errors in the logs, you can access the Acestream web interface using a web browser and going to `http://localhost:6878/webui/player/`. Here, you can directly load Acestream links into the field located in the upper left corner of the screen. When you wish, you can hide/show it with the icon to its left.

--- a/README_es.md
+++ b/README_es.md
@@ -80,6 +80,24 @@ docker run --name acestream -d -p 6878:6878 docker-acestream-ubuntu-home
 Este comando ejecutará un contenedor llamado `acestream`, en modo desacoplado (`-d`), mapeando el puerto `6878` del host
 al contenedor, permitiéndote acceder al servicio Acestream a través de este puerto.
 
+## Ejecución del Contenedor con Docker Compose
+
+Descarga o copia el contenido del fichero ``docker-compose.yml``.
+
+Desde la misma ruta donde lo hayas dejado, ejecuta:
+
+```bash
+docker compose up -d
+```
+
+### Actualizar con Docker Compose
+
+Ejecuta:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
 ## Acceso a Interfaz Web
 
 Una vez que el contenedor esté en ejecución y no haya errores en los logs, puedes acceder a la interfaz web de Acestream

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  acestream:
+    image: smarquezp/docker-acestream-ubuntu-home:latest
+    container_name: acestream
+    restart: unless-stopped
+    ports:
+      - 6878:6878
+networks:
+  default:
+    driver: bridge


### PR DESCRIPTION
Se añade un fichero ``docker-compose.yml`` base e instrucciones a los ``README.md`` para usarlo.

Había pensado añadir la variable ``INTERNAL_IP`` como variable de entorno en el compose, pero por mi parte he visto que el contenedor se levanta bien igualmente. Si ves que es necesario que añada la variable de entorno, aunque esté comentada por defecto, la pongo y actualizo la PR.